### PR TITLE
Add missing `Content-Length` header for `FormData` bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,6 +240,9 @@ function requestAsEventEmitter(opts) {
 		Promise.resolve(getBodySize(opts))
 			.then(size => {
 				uploadBodySize = size;
+				if (isFormData(opts.body)) {
+					opts.headers['content-length'] = size;
+				}
 				get(opts);
 			})
 			.catch(err => {


### PR DESCRIPTION
S3 requires form uploads to specify `Content-Length` header, otherwise
`411 Length Required` error is returned:
- https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html#mpUploadUploadPart-requests-request-headers
- https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList